### PR TITLE
Fix Auto-configuration locating for spring-boot 3.0.

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=io.github.gasparbarancelli.NativeQueryAutoConfiguration,\
-  io.github.gasparbarancelli.ApplicationContextProvider

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.github.gasparbarancelli.NativeQueryAutoConfiguration
+io.github.gasparbarancelli.ApplicationContextProvider


### PR DESCRIPTION
See:

- META-INF/spring.factories
  - Spring Boot 2.6.15: [9.2. Locating Auto-configuration Candidates](https://docs.spring.io/spring-boot/docs/2.6.15/reference/html/features.html#features.developing-auto-configuration.locating-auto-configuration-candidates)
- META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
  - Spring Boot 2.7.0: [9.2. Locating Auto-configuration Candidates](https://docs.spring.io/spring-boot/docs/2.7.0/reference/html/features.html#features.developing-auto-configuration.locating-auto-configuration-candidates)
  - Spring Boot 2.7.17: [9.2. Locating Auto-configuration Candidates](https://docs.spring.io/spring-boot/docs/2.7.17/reference/html/features.html#features.developing-auto-configuration.locating-auto-configuration-candidates)
  - Spring Boot 3.1.5: [10.2. Locating Auto-configuration Candidates](https://docs.spring.io/spring-boot/docs/3.1.5/reference/html/features.html#features.developing-auto-configuration.locating-auto-configuration-candidates)

And:
- [Spring Boot: new auto-configuration registration in v. 2.7](https://youtrack.jetbrains.com/issue/IDEA-289633)